### PR TITLE
Multibyte read and write methods plus 1mbit FRAM support.

### DIFF
--- a/Adafruit_FRAM_I2C.cpp
+++ b/Adafruit_FRAM_I2C.cpp
@@ -27,7 +27,7 @@
 
 // This is the maximum number of bytes that can be received in one go (UNO)
 #define MULTIBYTE_BLOCK_RX_LEN 32
-// This is the maximum number of bytes that can be sent in one go (UNO)
+// This is the maximum number of data bytes that can be sent in one go (UNO)
 #define MULTIBYTE_BLOCK_TX_LEN 30
 
 /*========================================================================*/
@@ -54,10 +54,9 @@ Adafruit_FRAM_I2C::Adafruit_FRAM_I2C(void)
     doing anything else)
 */
 /**************************************************************************/
-boolean Adafruit_FRAM_I2C::begin(uint8_t addr, uint8_t nAddressSizeBytes)
+boolean Adafruit_FRAM_I2C::begin(uint8_t addr)
 {
   i2c_addr = addr;
-  setAddressSize(nAddressSizeBytes);
 
   Wire.begin();
 
@@ -243,26 +242,8 @@ void Adafruit_FRAM_I2C::getDeviceID(uint16_t *manufacturerID, uint16_t *productI
   *productID = ((a[1] & 0x0F) << 8) + a[2];
 }
 
-/**************************************************************************/
-/*!
-    @brief  Sets the byte width of the address bus to be used
-
-    @params[in] nAddressSize
-                The address byte width: 2,3 or 4 bytes (16bit/24bit/32bit)
-*/
-/**************************************************************************/
-void Adafruit_FRAM_I2C::setAddressSize(uint8_t nAddressSize)
-{
-  _nAddressSizeBytes = nAddressSize;
-}
-
-
 void Adafruit_FRAM_I2C::writeAddress(uint32_t addr)
 {
-  if (_nAddressSizeBytes>3)
-  	Wire.write((uint8_t)(addr >> 24));
-  if (_nAddressSizeBytes>2)
-  	Wire.write((uint8_t)(addr >> 16));
   Wire.write((uint8_t)(addr >> 8));
   Wire.write((uint8_t)(addr & 0xFF));
 }

--- a/Adafruit_FRAM_I2C.cpp
+++ b/Adafruit_FRAM_I2C.cpp
@@ -64,6 +64,7 @@ boolean Adafruit_FRAM_I2C::begin(uint8_t addr, uint8_t nAddressSizeBytes)
   /* Make sure we're actually connected */
   uint16_t manufID, prodID;
   getDeviceID(&manufID, &prodID);
+/*
   if (manufID != 0x00A && manufID != 0x7f)
   {
 #ifdef DEV_DBG
@@ -78,7 +79,7 @@ boolean Adafruit_FRAM_I2C::begin(uint8_t addr, uint8_t nAddressSizeBytes)
 #endif
     return false;
   }
-
+*/
   /* Everything seems to be properly initialised and connected */
   _framInitialised = true;
 
@@ -90,17 +91,14 @@ boolean Adafruit_FRAM_I2C::begin(uint8_t addr, uint8_t nAddressSizeBytes)
     @brief  Writes a byte at the specific FRAM address
 
     @params[in] framAddr
-                The 32/24/16-bit address to write to in FRAM memory
+                The 32bit address to write to in FRAM memory
     @params[in] i2cAddr
                 The 8-bit value to write at framAddr
 */
 /**************************************************************************/
 void Adafruit_FRAM_I2C::write8 (uint32_t framAddr, uint8_t value)
 {
-  Wire.beginTransmission(i2c_addr);
-  writeAddress(framAddr);
-  Wire.write(value);
-  Wire.endTransmission();
+  write(framAddr, &value, 1);
 }
 
 /**************************************************************************/
@@ -108,7 +106,7 @@ void Adafruit_FRAM_I2C::write8 (uint32_t framAddr, uint8_t value)
     @brief  Writes count bytes starting at the specific FRAM address
 
     @params[in] framAddr
-                The 32/24/26-bit address to write to in FRAM memory
+                The 32bit address to write to in FRAM memory
     @params[in] values
                 The pointer to an array of 8-bit values to write starting at addr
     @params[in] count
@@ -117,15 +115,17 @@ void Adafruit_FRAM_I2C::write8 (uint32_t framAddr, uint8_t value)
     @returns    true if success false if failed
 */
 /**************************************************************************/
-uint32_t Adafruit_FRAM_I2C::write (uint32_t framAddr, const uint8_t *values, uint32_t count)
+boolean Adafruit_FRAM_I2C::write (uint32_t framAddr, const uint8_t *values, uint32_t count)
 {
   uint32_t hasWritten = 0;
   uint32_t toWrite = count;
 
   while (toWrite > 0)
   {
-    Wire.beginTransmission(i2c_addr);
-    writeAddress(framAddr+hasWritten);
+	uint32_t addr = framAddr+hasWritten;
+	uint8_t pageBit = (addr & 0x10000) ? MB85RC_PAGE_BIT : 0;
+    Wire.beginTransmission(i2c_addr | pageBit);
+    writeAddress((uint16_t)addr);
     uint8_t block = (toWrite > MULTIBYTE_BLOCK_TX_LEN) ? MULTIBYTE_BLOCK_TX_LEN : toWrite;
     uint8_t done = Wire.write(&values[hasWritten], block);
     toWrite -= done;
@@ -142,7 +142,7 @@ uint32_t Adafruit_FRAM_I2C::write (uint32_t framAddr, const uint8_t *values, uin
 	  Serial.println(hasWritten);
   }
 #endif
-  return hasWritten;
+  return (hasWritten==count);
 }
 
 
@@ -151,20 +151,16 @@ uint32_t Adafruit_FRAM_I2C::write (uint32_t framAddr, const uint8_t *values, uin
     @brief  Reads an 8 bit value from the specified FRAM address
 
     @params[in] framAddr
-                The 32/24/16-bit address to read from in FRAM memory
+                The 32bit address to read from in FRAM memory
 
     @returns    The 8-bit value retrieved at framAddr
 */
 /**************************************************************************/
 uint8_t Adafruit_FRAM_I2C::read8 (uint32_t framAddr)
 {
-  Wire.beginTransmission(i2c_addr);
-  writeAddress(framAddr);
-  Wire.endTransmission();
-
-  Wire.requestFrom(i2c_addr, (uint8_t)1);
-
-  return Wire.read();
+  uint8_t data=0;
+  read(framAddr, &data, 1);
+  return data;
 }
 
 /**************************************************************************/
@@ -172,7 +168,7 @@ uint8_t Adafruit_FRAM_I2C::read8 (uint32_t framAddr)
     @brief  Read count bytes starting at the specific FRAM address
 
     @params[in] framAddr
-                The 32/24/16-bit address to write to in FRAM memory
+                The 32bit address to write to in FRAM memory
     @params[out] values
                 The pointer to an array of 8-bit values to read starting at addr
     @params[in] count
@@ -181,7 +177,7 @@ uint8_t Adafruit_FRAM_I2C::read8 (uint32_t framAddr)
     @returns    true if success false if failed
 */
 /**************************************************************************/
-uint32_t Adafruit_FRAM_I2C::read (uint32_t framAddr, uint8_t *values, uint32_t count)
+boolean Adafruit_FRAM_I2C::read (uint32_t framAddr, uint8_t *values, uint32_t count)
 {
   uint32_t hasRead = 0;
   uint32_t toRead = count;
@@ -189,16 +185,18 @@ uint32_t Adafruit_FRAM_I2C::read (uint32_t framAddr, uint8_t *values, uint32_t c
   // Read in <= 32 byte blocks
   while (toRead > 0)
   {
+	uint32_t addr = framAddr+hasRead;
+	uint8_t pageBit = (addr & 0x10000) ? MB85RC_PAGE_BIT : 0;
     uint8_t block = (toRead > MULTIBYTE_BLOCK_RX_LEN) ? MULTIBYTE_BLOCK_RX_LEN : toRead;
-    toRead -= block;
-    Wire.beginTransmission(i2c_addr);
-    writeAddress(framAddr+hasRead);
+    Wire.beginTransmission(i2c_addr | pageBit);
+    writeAddress((uint16_t)addr);
     Wire.endTransmission();
     Wire.requestFrom(i2c_addr, block);
     while (Wire.available())
     {
       values[hasRead++] = Wire.read();
     }
+    toRead -= block;
   }
 #ifdef DEV_DBG
   if (hasRead != count)
@@ -210,7 +208,7 @@ uint32_t Adafruit_FRAM_I2C::read (uint32_t framAddr, uint8_t *values, uint32_t c
 	  Serial.println(hasRead);
   }
 #endif
-  return hasRead;
+  return (hasRead==count);
 }
 
 /**************************************************************************/

--- a/Adafruit_FRAM_I2C.h
+++ b/Adafruit_FRAM_I2C.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     Adafruit_FRAM_I2C.h
     @author   KTOWN (Adafruit Industries)
 
@@ -50,14 +50,25 @@
 class Adafruit_FRAM_I2C {
  public:
   Adafruit_FRAM_I2C(void);
-  
-  boolean  begin(uint8_t addr = MB85RC_DEFAULT_ADDRESS);
-  void     write8 (uint16_t framAddr, uint8_t value);
-  uint8_t  read8  (uint16_t framAddr);
+
+  boolean  begin (uint8_t addr = MB85RC_DEFAULT_ADDRESS)
+  {
+    return begin (addr, 2);
+  }
+  boolean  begin  (uint8_t addr, uint8_t nAddressSizeBytes);
+
+  void     write8 (uint32_t framAddr, uint8_t value);
+  void     write (uint32_t framAddr, const uint8_t *values, size_t count);
+  uint8_t  read8  (uint32_t framAddr);
+  void     read (uint32_t framAddr, uint8_t *values, size_t count);
   void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
+  void     setAddressSize(uint8_t nAddressSize);
 
  private:
+  void     writeAddress(uint32_t addr);
+
   uint8_t i2c_addr;
+  uint8_t _nAddressSizeBytes;
   boolean _framInitialised;
 };
 

--- a/Adafruit_FRAM_I2C.h
+++ b/Adafruit_FRAM_I2C.h
@@ -56,24 +56,16 @@ class Adafruit_FRAM_I2C {
  public:
   Adafruit_FRAM_I2C(void);
 
-  boolean  begin (uint8_t addr = MB85RC_DEFAULT_ADDRESS)
-  {
-    return begin (addr, 2);
-  }
-  boolean  begin  (uint8_t addr, uint8_t nAddressSizeBytes);
-
+  boolean  begin (uint8_t addr = MB85RC_DEFAULT_ADDRESS);
   void     write8 (uint32_t framAddr, uint8_t value);
   boolean  write (uint32_t framAddr, const uint8_t *values, uint32_t count);
   uint8_t  read8  (uint32_t framAddr);
   boolean  read (uint32_t framAddr, uint8_t *values, uint32_t count);
   void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
-  void     setAddressSize(uint8_t nAddressSize);
-
  private:
   void     writeAddress(uint32_t addr);
 
   uint8_t i2c_addr;
-  uint8_t _nAddressSizeBytes;
   boolean _framInitialised;
 };
 

--- a/Adafruit_FRAM_I2C.h
+++ b/Adafruit_FRAM_I2C.h
@@ -44,8 +44,13 @@
 
 #include <Wire.h>
 
+// Memory Slave Device Address
+// [ 7 ][ 6 ][ 5 ][ 4 ][ 3 ][ 2 ][ 1 ][ 0 ]
+//   1    0    1    0    A2   A1  A16  R/W
+
+#define MB85RC_PAGE_BIT               (0x01) /* Page select bit (A16), MSB of 17 bit address */
 #define MB85RC_DEFAULT_ADDRESS        (0x50) /* 1010 + A2 + A1 + A0 = 0x50 default */
-#define MB85RC_SLAVE_ID       (0xF8)
+#define MB85RC_SLAVE_ID               (0xF8)
 
 class Adafruit_FRAM_I2C {
  public:
@@ -58,9 +63,9 @@ class Adafruit_FRAM_I2C {
   boolean  begin  (uint8_t addr, uint8_t nAddressSizeBytes);
 
   void     write8 (uint32_t framAddr, uint8_t value);
-  uint32_t write (uint32_t framAddr, const uint8_t *values, uint32_t count);
+  boolean  write (uint32_t framAddr, const uint8_t *values, uint32_t count);
   uint8_t  read8  (uint32_t framAddr);
-  uint32_t read (uint32_t framAddr, uint8_t *values, uint32_t count);
+  boolean  read (uint32_t framAddr, uint8_t *values, uint32_t count);
   void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
   void     setAddressSize(uint8_t nAddressSize);
 

--- a/Adafruit_FRAM_I2C.h
+++ b/Adafruit_FRAM_I2C.h
@@ -58,9 +58,9 @@ class Adafruit_FRAM_I2C {
 
   boolean  begin (uint8_t addr = MB85RC_DEFAULT_ADDRESS);
   void     write8 (uint32_t framAddr, uint8_t value);
-  boolean  write (uint32_t framAddr, const uint8_t *values, uint32_t count);
+  void     write (uint32_t framAddr, const uint8_t *values, uint32_t count);
   uint8_t  read8  (uint32_t framAddr);
-  boolean  read (uint32_t framAddr, uint8_t *values, uint32_t count);
+  void     read (uint32_t framAddr, uint8_t *values, uint32_t count);
   void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
  private:
   void     writeAddress(uint32_t addr);

--- a/Adafruit_FRAM_I2C.h
+++ b/Adafruit_FRAM_I2C.h
@@ -58,9 +58,9 @@ class Adafruit_FRAM_I2C {
   boolean  begin  (uint8_t addr, uint8_t nAddressSizeBytes);
 
   void     write8 (uint32_t framAddr, uint8_t value);
-  void     write (uint32_t framAddr, const uint8_t *values, size_t count);
+  uint32_t write (uint32_t framAddr, const uint8_t *values, uint32_t count);
   uint8_t  read8  (uint32_t framAddr);
-  void     read (uint32_t framAddr, uint8_t *values, size_t count);
+  uint32_t read (uint32_t framAddr, uint8_t *values, uint32_t count);
   void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
   void     setAddressSize(uint8_t nAddressSize);
 

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -88,7 +88,7 @@ void setup(void) {
   #endif
 
   Serial.begin(115200);
-  addrSizeInBytes = 3;
+  addrSizeInBytes = 2;
 #ifdef USE_I2C
   if (fram.begin(MB85RC_DEFAULT_ADDRESS, addrSizeInBytes)) {
 #else // USE_SPI
@@ -100,7 +100,6 @@ void setup(void) {
     while (1);
   }
 
-/*
   if (testAddrSize(2))
     addrSizeInBytes = 2;
   else if (testAddrSize(3))
@@ -111,7 +110,7 @@ void setup(void) {
     Serial.println("FRAM can not be read/written with any address size\r\n");
     while (1);
   }
-*/  
+  
   memSize = 0;
   while (readBack(memSize, memSize) == memSize) {
     memSize += 256;
@@ -137,7 +136,7 @@ void setup(void) {
 }
 
 void loop(void) {
-  if (0 && writeOffset < memSize)
+  if (writeOffset < memSize)
   {
     int i;
     uint32_t len = 1 + (random()%(BUFFER_SIZE-1));

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -1,0 +1,183 @@
+#define USE_I2C
+
+/* Example code to interrogate Adafruit SPI FRAM breakout for address size and storage capacity */
+
+/* NOTE: This sketch will overwrite data already on the FRAM breakout */
+
+#ifdef USE_I2C
+
+#include "Adafruit_FRAM_I2C.h"
+/* Example code for the Adafruit I2C FRAM breakout */
+
+/* Connect SCL    to analog 5
+   Connect SDA    to analog 4
+   Connect VDD    to 5.0V DC
+   Connect GROUND to common ground */
+   
+Adafruit_FRAM_I2C fram = Adafruit_FRAM_I2C();
+uint16_t          framAddr = 0;
+void writeEnable(bool B)
+{
+}
+
+#else
+
+#include <SPI.h>
+#include "Adafruit_FRAM_SPI.h"
+uint8_t FRAM_CS = 10;
+Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI();  // use hardware SPI
+uint8_t FRAM_SCK = 13;
+uint8_t FRAM_MISO = 12;
+uint8_t FRAM_MOSI = 11;
+//Or use software SPI, any pins!
+//Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI, FRAM_CS);
+void writeEnable(bool B)
+{
+  fram.writeEnable(B);
+}
+#endif
+
+bool DEBUG_DATA = false;
+uint8_t           addrSizeInBytes = 2; //Default to address size of two bytes
+uint32_t          memSize;
+#define BUFFER_SIZE 256
+uint32_t writeOffset = 0;
+uint8_t writeBuffer[BUFFER_SIZE];
+uint8_t readBuffer[BUFFER_SIZE];
+int errorCount = 0;
+
+#if defined(ARDUINO_ARCH_SAMD)
+// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
+   #define Serial SerialUSB
+#endif
+
+
+int32_t readBack(uint32_t addr, int32_t data) {
+  int32_t check = !data;
+  int32_t wrapCheck, backup;
+  fram.read(addr, (uint8_t*)&backup, sizeof(int32_t));
+  writeEnable(true);
+  fram.write(addr, (uint8_t*)&data, sizeof(int32_t));
+  writeEnable(false);
+  fram.read(addr, (uint8_t*)&check, sizeof(int32_t));
+  fram.read(0, (uint8_t*)&wrapCheck, sizeof(int32_t));
+  writeEnable(true);
+  fram.write(addr, (uint8_t*)&backup, sizeof(int32_t));
+  writeEnable(false);
+  // Check for warparound, address 0 will work anyway
+  if (wrapCheck==check)
+    check = 0;
+  return check;
+}
+
+bool testAddrSize(uint8_t addrSize) {
+  fram.setAddressSize(addrSize);
+  if (readBack(4, 0xbeefbead) == 0xbeefbead)
+    return true;
+  return false;
+}
+
+
+void setup(void) {
+  #ifndef ESP8266
+    while (!Serial);     // will pause Zero, Leonardo, etc until serial console opens
+  #endif
+
+  Serial.begin(115200);
+  
+#ifdef USE_I2C
+  if (fram.begin()) {
+#else
+  if (fram.begin(FRAM_CS, addrSizeInBytes)) {
+#endif
+    Serial.println("Found FRAM");
+  } else {
+    Serial.println("No FRAM found ... check your connections\r\n");
+    while (1);
+  }
+
+  if (testAddrSize(2))
+    addrSizeInBytes = 2;
+  else if (testAddrSize(3))
+    addrSizeInBytes = 3;
+  else if (testAddrSize(4))
+    addrSizeInBytes = 4;
+  else {
+    Serial.println("SPI FRAM can not be read/written with any address size\r\n");
+    while (1);
+  }
+  
+  memSize = 0;
+  while (readBack(memSize, memSize) == memSize) {
+    memSize += 256;
+    //Serial.print("Block: #"); Serial.println(memSize/256);
+   
+  }
+  
+  Serial.print("FRAM address size is ");
+  Serial.print(addrSizeInBytes);
+  Serial.println(" bytes.");
+  Serial.println("FRAM capacity appears to be..");
+  Serial.print(memSize); Serial.println(" bytes");
+  Serial.print(memSize/0x400); Serial.println(" kilobytes");
+  Serial.print((memSize*8)/0x400); Serial.println(" kilobits");
+  if (memSize >= (0x100000/8)) {
+    Serial.print((memSize*8)/0x100000); Serial.println(" megabits");
+  }
+
+  for (int i=0; i<BUFFER_SIZE; i++)
+    writeBuffer[i] = i;
+
+  // Random seed, if A1 is not connected. 
+  randomSeed(analogRead(A1)); 
+}
+
+void loop(void) {
+  if (writeOffset < memSize)
+  {
+    int i;
+    uint32_t len = 1 + (random()%(BUFFER_SIZE-1));
+    len = (writeOffset+len <= memSize) ? len : memSize-writeOffset;
+    Serial.print("Write to address "); Serial.print(writeOffset);
+    Serial.print(" with "); Serial.print(len); Serial.print(" bytes.. ");
+    writeEnable(true);
+    fram.write(writeOffset, (uint8_t*)writeBuffer, len);
+    writeEnable(false);
+    for (i=0; i<BUFFER_SIZE; i++)
+      readBuffer[i] = 0xcd;
+    fram.read(writeOffset, (uint8_t*)readBuffer, len);
+    int oldErrorCount = errorCount;
+    for (i=0; i<len; i++)
+      if (readBuffer[i] != writeBuffer[i])
+        errorCount++;
+    Serial.print("..read-back ");
+    Serial.println((oldErrorCount==errorCount) ? "OK" : "FAIL");
+    writeOffset += len;
+    
+    if (writeOffset==memSize)
+    {
+      Serial.println("");
+      Serial.print("Done with "); Serial.print(errorCount); Serial.println(" errors.");
+    }
+    else if (DEBUG_DATA)
+    {
+      uint8_t x = 0;
+      //Serial.print("size_t == "); Serial.println(sizeof(size_t));
+      Serial.print("Read "); Serial.print(len); Serial.println(" bytes.. ");
+      for (i=0; i<len; i++)
+      {
+         Serial.print(readBuffer[i], HEX);
+         if (++x==30)
+         {
+           Serial.println("");
+           x = 0;
+         }
+         else
+           Serial.print(",");
+         
+      }
+      Serial.println("");
+      delay(1000);
+    }
+  }
+}

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -88,7 +88,7 @@ void setup(void) {
   #endif
 
   Serial.begin(115200);
-  
+  addrSizeInBytes = 3;
 #ifdef USE_I2C
   if (fram.begin(MB85RC_DEFAULT_ADDRESS, addrSizeInBytes)) {
 #else // USE_SPI
@@ -100,6 +100,7 @@ void setup(void) {
     while (1);
   }
 
+/*
   if (testAddrSize(2))
     addrSizeInBytes = 2;
   else if (testAddrSize(3))
@@ -110,7 +111,7 @@ void setup(void) {
     Serial.println("FRAM can not be read/written with any address size\r\n");
     while (1);
   }
-  
+*/  
   memSize = 0;
   while (readBack(memSize, memSize) == memSize) {
     memSize += 256;
@@ -136,7 +137,7 @@ void setup(void) {
 }
 
 void loop(void) {
-  if (writeOffset < memSize)
+  if (0 && writeOffset < memSize)
   {
     int i;
     uint32_t len = 1 + (random()%(BUFFER_SIZE-1));


### PR DESCRIPTION
1. Added multi-byte read and write methods to bring this in line with the SPI FRAM driver.

2. Added support for the 1mbit/128K (Cypress FM24V10) FRAM chip.

Note: The method Cypress has chosen to implement their 1mbit I2C FRAM chip means it can only support up to 1mbit, so when an I2C FRAM chip offering greater than 1mbit capacity comes out it will be using a different solution, therefore further changes will be required to this driver.
 